### PR TITLE
protocol075.md: Change kill packetID to 16

### DIFF
--- a/protocol075.md
+++ b/protocol075.md
@@ -550,7 +550,7 @@ the packet after the gamemode id portion.
 Notify the client of a player's death.
 
 | ----------: | -------- |
-| Packet ID   | 18       |
+| Packet ID   | 16       |
 | Total Size: | 5 bytes  |
 
 | Field Name       | Field Type | Example | Notes                 |


### PR DESCRIPTION
The kill packetID isnt 18. Its actually 16.
This was found when developing a new server from scratch
and implementing killing action. We would get client to start loading map instead of kill.