### PR TITLE
protocol075.md: Swap killerID and playerID

### DIFF
--- a/protocol075.md
+++ b/protocol075.md
@@ -555,8 +555,8 @@ Notify the client of a player's death.
 
 | Field Name       | Field Type | Example | Notes                 |
 |------------------|------------|---------|-----------------------|
-| player ID        | UByte      | 12      | Player that died      |
-| killer ID        | UByte      | 8       |                       |
+| killer ID        | UByte      | 12      | Player that shot      |
+| player ID        | UByte      | 8       | Player that got shot  |
 | kill type        | UByte      | 0       | See table below       |
 | respawn time     | UByte      | 1       | Seconds until respawn |
 


### PR DESCRIPTION
As im slowly developing my server i find more and more bugs. This time when i shot player instead
of the player dying it notified me that i got killed by the player i shot.
Confirmed this is not a bug on my side.