### PR TITLE
protocol075.md: Intel Drop packet size is 14

### DIFF
--- a/protocol075.md
+++ b/protocol075.md
@@ -746,7 +746,7 @@ Sent when a player dropped the intel. This will update the intel position on the
 
 | ----------: | -------- |
 | Packet ID   | 25       |
-| Total Size: | 13 bytes |
+| Total Size: | 14 bytes |
 
 #### Fields
 


### PR DESCRIPTION
13 byte is wrong as the packet type byte was not counted in.
Count it in.