### PR TITLE
Correct extensions page

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -49,7 +49,7 @@ General extension packet structure:
 ## Protocol Flow
 
 The server should send an `ExtInfo` packet (optimally) after the Version Info response has been received to compatible clients
-(OpenSpades versions > 0.1.3),
+(OpenSpades versions > 0.1.3, see https://github.com/piqueserver/piqueserver/issues/504),
 assuming it supports any. The client can store the list of extensions for later use and should
 reply with an `ExtInfo` packet that lists the extensions it supports (if it does actually support any).
 


### PR DESCRIPTION
Reasons for the corrections:
Just using 'n' is a little bit confusing, so I change it to "length".

length+1 entries do not follow, just length follows. This agrees with the 2+2*length thing positioned just above the statement.

All extensions that I have seen have had a version of 1, so I change it to reflect that.

The server does not need to send an ExtInfo packet on connect at all, since extensions are... extensions. They are optional additions that are not an official part of the AoS v0.75 protocol. The same can be said for the client (and if the length+1 thing were true there would be no way to not support extensions without making up a fake one). And there is no need to omit any extensions that the server does not support as the server can simply ignore extensions that it does not support. So I delete this entire section.

I also fix some spacing that was messed up on a markdown table.