### PR TITLE
Info for kill action type behaviour in aos classic

### DIFF
--- a/protocol075.md
+++ b/protocol075.md
@@ -565,6 +565,9 @@ Notify the client of a player's death.
 
 #### Fields
 
+If sent any value higher than 6 in Ace of Spades (voxlap), game
+will display the kill message as "Derpy Kill Message"
+
 | Value | Type                 |
 |-------|----------------------|
 | 0     | WEAPON (body, limbs) |


### PR DESCRIPTION
This adds a info about what happens when sending a Kill type higher than 6 in voxlap, that will result in displaying the message "Derpy Kill Message" in the kill feed.