### PR TITLE
document player properties, ed25519 auth, and utf-8 chat extensions

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -72,6 +72,39 @@ Sends additional player attributes from the server to the client.
 |--------|-------------------|------------------|------|
 | 0      | Player Properties | Server -> Client | 12   |
 
+### Sub ID 0: Player Properties
+
+The server sends this packet to inform the client of authoritative stats for
+a single player. There is no client-to-server form. The 12-byte total
+includes the Packet ID and Sub Packet ID as described in the
+[general extension packet structure](#overview).
+
+| Field Name    | Field Type | Example | Notes                                                                                                     |
+|---------------|------------|---------|-----------------------------------------------------------------------------------------------------------|
+| Packet ID     | UByte      | `64`    | Always `64`.                                                                                              |
+| Sub Packet ID | UByte      | `0`     | Always `0` for this sub-packet.                                                                           |
+| Player ID     | UByte      | `0`     | The id of the player these stats describe.                                                                |
+| HP            | UByte      | `100`   | Health, `0`..`100`. `0` indicates the player is dead.                                                     |
+| Blocks        | UByte      | `50`    | Block count currently carried by the player. Typically `0`..`50` for vanilla servers.                     |
+| Grenades      | UByte      | `3`     | Grenade count currently carried by the player. Typically `0`..`3` for vanilla servers.                    |
+| Magazine Ammo | UByte      | `10`    | Ammunition currently loaded in the player's equipped weapon clip.                                         |
+| Reserve Ammo  | UByte      | `50`    | Spare ammunition the player has for the equipped weapon (outside the clip).                               |
+| Score         | LE Uint    | `7`     | The player's score, as defined by the server (e.g. kills, or kills plus objective points). 32-bit, little-endian. |
+
+Byte layout (offsets are within the packet, including the Packet ID byte):
+
+| Offset | Size | Field         |
+|--------|------|---------------|
+| 0      | 1    | Packet ID     |
+| 1      | 1    | Sub Packet ID |
+| 2      | 1    | Player ID     |
+| 3      | 1    | HP            |
+| 4      | 1    | Blocks        |
+| 5      | 1    | Grenades      |
+| 6      | 1    | Magazine Ammo |
+| 7      | 1    | Reserve Ammo  |
+| 8      | 4    | Score         |
+
 
 # Packetless Packets
 * [Player Limit](#player-limit)

--- a/extensions.md
+++ b/extensions.md
@@ -84,12 +84,12 @@ includes the Packet ID and Sub Packet ID as described in the
 | Packet ID     | UByte      | `64`    | Always `64`.                                                                                              |
 | Sub Packet ID | UByte      | `0`     | Always `0` for this sub-packet.                                                                           |
 | Player ID     | UByte      | `0`     | The id of the player these stats describe.                                                                |
-| HP            | UByte      | `100`   | Health, `0`..`100`. `0` indicates the player is dead.                                                     |
+| HP            | UByte      | `100`   | Health. A `UByte`, so the wire range is `0`..`255`; vanilla servers use `0`..`100`. Whether `0` HP marks the player as dead is client-specific (betterspades does not — the kill packet is authoritative for death; openspades does, but does not support this packet). |
 | Blocks        | UByte      | `50`    | Block count currently carried by the player. Typically `0`..`50` for vanilla servers.                     |
 | Grenades      | UByte      | `3`     | Grenade count currently carried by the player. Typically `0`..`3` for vanilla servers.                    |
 | Magazine Ammo | UByte      | `10`    | Ammunition currently loaded in the player's equipped weapon clip.                                         |
 | Reserve Ammo  | UByte      | `50`    | Spare ammunition the player has for the equipped weapon (outside the clip).                               |
-| Score         | LE Uint    | `7`     | The player's score, as defined by the server (e.g. kills, or kills plus objective points). 32-bit, little-endian. |
+| Score         | LE Uint    | `7`     | The player's score, as defined by the server (e.g. kills, or kills plus objective points). 32-bit little-endian integer. Reference clients treat it as unsigned (BetterSpades, KyroSpades); zerospades reads it into a signed `int`. Signedness is only observable for values >= 2^31. |
 
 Byte layout (offsets are within the packet, including the Packet ID byte):
 

--- a/extensions.md
+++ b/extensions.md
@@ -57,6 +57,44 @@ The client can omit any extensions that the server does not support from its
 reply, but this is not necessary as the server can simply ignore them itself.
 
 
+# HAS_PACKETS Packets
+* [Player Properties](#player-properties)
+* [Ed25519 Authentication](#ed25519-authentication)
+
+## Player Properties
+
+Sends additional player attributes from the server to the client.
+
+| ---------: |-----|
+| Packet ID: | 64  |
+| Version:   | 1   |
+
+| Sub ID | Name              | Direction        | Size |
+|--------|-------------------|------------------|------|
+| 0      | Player Properties | Server -> Client | 12   |
+
+## Ed25519 Authentication
+
+Authenticates a connecting client using an Ed25519 key pair. The server requests
+authentication and sends a nonce, the client replies with its public key and a
+signature over the nonce, and the server ends authentication once the signature
+has been verified.
+
+| ---------: |-----|
+| Packet ID: | 65  |
+| Version:   | 1   |
+
+#### Sub Packets:
+
+| Sub ID | Name                   | Direction        | Size |
+|--------|------------------------|------------------|------|
+| 0      | Request Authentication | Server -> Client | 2    |
+| 1      | End Authentication     | Server -> Client | 4+   |
+| 2      | Send Public Key        | Client -> Server | 34   |
+| 3      | Send Nonce             | Server -> Client | 3+   |
+| 4      | Send Signature         | Client -> Server | 66   |
+
+
 # Packetless Packets
 * [Player Limit](#player-limit)
 * [Message Types](#message-types)
@@ -97,3 +135,13 @@ kicking a player out of the server.
 | ---------: |-----|
 | Packet ID: | 194 |
 | Version:   | 1   |
+
+# Other Extensions
+* [UTF-8 Chat](#utf-8-chat)
+
+## UTF-8 Chat
+
+Has no registered extension id. A [Chat Message](protocol075.html#chat-message)
+whose data starts with a `0xff` byte is encoded in UTF-8 instead of Code Page
+437. Messages without the prefix are interpreted as Code Page 437 as in the
+base protocol.

--- a/extensions.md
+++ b/extensions.md
@@ -57,6 +57,22 @@ The client can omit any extensions that the server does not support from its
 reply, but this is not necessary as the server can simply ignore them itself.
 
 
+# HAS_PACKETS Packets
+* [Player Properties](#player-properties)
+
+## Player Properties
+
+Sends additional player attributes from the server to the client.
+
+| ---------: |-----|
+| Packet ID: | 64  |
+| Version:   | 1   |
+
+| Sub ID | Name              | Direction        | Size |
+|--------|-------------------|------------------|------|
+| 0      | Player Properties | Server -> Client | 12   |
+
+
 # Packetless Packets
 * [Player Limit](#player-limit)
 * [Message Types](#message-types)
@@ -97,3 +113,13 @@ kicking a player out of the server.
 | ---------: |-----|
 | Packet ID: | 194 |
 | Version:   | 1   |
+
+# Other Extensions
+* [UTF-8 Chat](#utf-8-chat)
+
+## UTF-8 Chat
+
+Has no registered extension id. A [Chat Message](protocol075.html#chat-message)
+whose data starts with a `0xff` byte is encoded in UTF-8 instead of Code Page
+437. Messages without the prefix are interpreted as Code Page 437 as in the
+base protocol.

--- a/index.md
+++ b/index.md
@@ -25,9 +25,9 @@ Packetful extensions are extensions that can be used to send packets. Each
 extension has 256 packet types reserved for itself. This is useful for adding
 functionality that requires sending additional information from or to the client.
 
-| ID | Name          | Description                                          | Link |
-|----|---------------|------------------------------------------------------|------|
-|    |               |                                                      |      |
+| ID | Name              | Description                                                      | Link                                                   |
+|----|-------------------|------------------------------------------------------------------|--------------------------------------------------------|
+| 0  | Player Properties | Sends additional player attributes from the server to the client | [Player Properties](extensions.html#player-properties) |
 
 
 ### Packetless Extensions

--- a/index.md
+++ b/index.md
@@ -25,9 +25,10 @@ Packetful extensions are extensions that can be used to send packets. Each
 extension has 256 packet types reserved for itself. This is useful for adding
 functionality that requires sending additional information from or to the client.
 
-| ID | Name          | Description                                          | Link |
-|----|---------------|------------------------------------------------------|------|
-|    |               |                                                      |      |
+| ID | Name                   | Description                                                       | Link                                                              |
+|----|------------------------|-------------------------------------------------------------------|-------------------------------------------------------------------|
+| 0  | Player Properties      | Sends additional player attributes from the server to the client | [Player Properties](extensions.html#player-properties)            |
+| 1  | Ed25519 Authentication | Authenticates a client to the server using an Ed25519 key pair   | [Ed25519 Authentication](extensions.html#ed25519-authentication)  |
 
 
 ### Packetless Extensions


### PR DESCRIPTION
Bring extensions.md in line with libspades' extension docs — adds
Player Properties (id 0), Ed25519 Authentication (id 1), and a note
about UTF-8 Chat. Also fills in the empty has-packets table in
index.md so it actually lists something.

These are not really proposals as these have already been widely adopted.

Sources:
- https://totallynotaburner.codeberg.page/libspades/extensions.html
- https://totallynotaburner.codeberg.page/libspades/packetByID.html#packets_extensions